### PR TITLE
fix: make StreamingBody context manager mirror aiohttp ClientResponse (#106)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiomoto"
-version = "0.5.0"
+version = "0.5.1"
 description = "Moto-style AWS service mocks for aiobotocore"
 readme = "README.md"
 authors = [

--- a/src/aiomoto/patches/core.py
+++ b/src/aiomoto/patches/core.py
@@ -23,46 +23,42 @@ _AIO_SESSION_CREATE_CLIENT_ATTR = "_create_client"
 _AIO_HIERARCHICAL_EMITTER_EMIT_ATTR = "_emit"
 
 
-class _AioBytesIOAdapter:
-    """Async wrapper around Moto's in-memory response body.
+def _infer_length(raw: Any) -> int | None:
+    if hasattr(raw, "getbuffer"):
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            return len(raw.getbuffer())
+    if hasattr(raw, "__len__"):
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            return len(raw)
+    length = getattr(raw, "len", None)
+    return int(length) if isinstance(length, int) else None
 
-    The adapter exposes the minimal surface that aiobotocore's StreamingBody
-    expects from an aiohttp.ClientResponse: a ``content.read`` coroutine,
-    ``at_eof`` helper, and ``url`` attribute. ``content`` points back to the
-    adapter to mirror aiohttp's layout. Some callers (for example s3fs) also
-    expect a ``close`` method on the body; the adapter provides a no-op close
-    that forwards to the underlying raw object when available.
+
+class _AioStreamReader:
+    """Async stand-in for aiohttp's ``StreamReader`` (``ClientResponse.content``).
+
+    ``StreamingBody.read(amt)`` delegates to ``raw.content.read(amt)``, so this
+    object accepts the size argument that aiohttp's ``StreamReader`` supports. The
+    enclosing :class:`_AioBytesIOAdapter` (which mirrors ``aiohttp.ClientResponse``)
+    deliberately does not, so context-manager misuse is surfaced rather than masked.
     """
 
-    def __init__(self, raw: Any, url: str) -> None:
+    def __init__(self, raw: Any, length: int | None) -> None:
         self._raw = raw
-        self.url = url
-        self.content = self  # StreamingBody calls ``raw.content.read``.
-        self._length = self._infer_length()
+        self._length = length
         self._eof = False
-        self.closed = False
 
-    def _infer_length(self) -> int | None:
-        if hasattr(self._raw, "getbuffer"):
-            with contextlib.suppress(Exception):  # pragma: no cover - defensive
-                return len(self._raw.getbuffer())
-        if hasattr(self._raw, "__len__"):
-            with contextlib.suppress(Exception):  # pragma: no cover - defensive
-                return len(self._raw)
-        length = getattr(self._raw, "len", None)
-        return int(length) if isinstance(length, int) else None
-
-    def _update_eof(self, read_len: int) -> None:
+    def _update_eof(self) -> None:
         if self._length is not None and hasattr(self._raw, "tell"):
             with contextlib.suppress(Exception):  # pragma: no cover - defensive
                 self._eof = self._raw.tell() >= self._length
 
     def at_eof(self) -> bool:
-        self._update_eof(0)
+        self._update_eof()
         return self._eof
 
-    async def read(self, amt: int | None = None) -> bytes:
-        data = self._raw.read() if amt is None else self._raw.read(amt)
+    async def read(self, n: int = -1) -> bytes:
+        data = self._raw.read() if n < 0 else self._raw.read(n)
         if data is None:
             data = b""
         if isinstance(data, bytes):
@@ -71,15 +67,49 @@ class _AioBytesIOAdapter:
             data_bytes = bytes(data)
         else:  # pragma: no cover - defensive
             data_bytes = bytes(data)
-        self._update_eof(len(data_bytes))
+        self._update_eof()
         return data_bytes
+
+    def close(self) -> None:
+        self._eof = True
+
+
+class _AioBytesIOAdapter:
+    """Async stand-in for the ``aiohttp.ClientResponse`` Moto would return.
+
+    aiobotocore wraps this object in a ``StreamingBody`` proxy, so it must expose
+    the surface ``StreamingBody`` reads from a ``ClientResponse``: a ``content``
+    stream reader (``raw.content.read``), an ``at_eof`` helper, and a ``url``
+    attribute. ``read`` mirrors ``aiohttp.ClientResponse.read`` and takes no size
+    argument, so misuse such as ``async with body as stream: await stream.read(amt)``
+    fails here the same way it does against real S3 instead of being silently
+    smoothed over. Some callers (for example s3fs) also expect ``close``; the
+    adapter forwards it to the underlying raw object when available.
+    """
+
+    def __init__(self, raw: Any, url: str) -> None:
+        self._raw = raw
+        self.url = url
+        self.content = _AioStreamReader(raw, _infer_length(raw))
+        self.closed = False
+
+    def at_eof(self) -> bool:
+        return self.content.at_eof()
+
+    async def read(self) -> bytes:
+        """Read the full response body, mirroring ``aiohttp.ClientResponse.read``.
+
+        Returns:
+            bytes: The remaining response payload.
+        """
+        return await self.content.read(-1)
 
     def close(self) -> None:
         close_fn = getattr(self._raw, "close", None)
         if close_fn:
             with contextlib.suppress(Exception):  # pragma: no cover - defensive
                 close_fn()
-        self._eof = True
+        self.content.close()
         self.closed = True
 
     async def __aenter__(self) -> _AioBytesIOAdapter:

--- a/tests/patches/test_core_internal.py
+++ b/tests/patches/test_core_internal.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 from types import SimpleNamespace
 from typing import Any
 
@@ -12,6 +13,7 @@ from aiomoto.exceptions import RealHTTPRequestBlockedError
 from aiomoto.patches.core import (
     _AIO_ENDPOINT_SEND_ATTR,
     _AioBytesIOAdapter,
+    _infer_length,
     _materialize_request_body,
     _wrap_stubber_handler,
     CorePatcher,
@@ -43,10 +45,9 @@ class _DummyBodyNone:
 @pytest.mark.asyncio
 async def test_aio_bytes_io_adapter_branches() -> None:
     adapter = _AioBytesIOAdapter(_DummyBodyWithLen(b"abc"), "url")
-    assert adapter._infer_length() == 3
+    assert _infer_length(adapter._raw) == 3
     assert adapter.at_eof() is False
     assert await adapter.read() == b"abc"
-    assert await adapter.read(2) == b"ab"
     assert adapter.at_eof() is False
     adapter.close()
     assert adapter.closed is True
@@ -59,6 +60,16 @@ async def test_aio_bytes_io_adapter_branches() -> None:
     adapter2 = _AioBytesIOAdapter(_DummyBodyNone(), "url")
     assert await adapter2.read() == b""
     assert adapter2.at_eof() is False
+
+
+@pytest.mark.asyncio
+async def test_adapter_read_rejects_size_like_client_response() -> None:
+    adapter = _AioBytesIOAdapter(io.BytesIO(b"abcdef"), "url")
+    with pytest.raises(TypeError):
+        await adapter.read(2)  # ClientResponse.read() takes no size argument
+
+    assert await adapter.content.read(2) == b"ab"
+    assert await adapter.content.read(-1) == b"cdef"
 
 
 @pytest.mark.asyncio

--- a/tests/patches/test_core_internal.py
+++ b/tests/patches/test_core_internal.py
@@ -28,10 +28,8 @@ class _DummyBodyWithLen:
     def __len__(self) -> int:
         return len(self._payload)
 
-    def read(self, amt: int | None = None) -> bytes:
-        if amt is None:
-            return self._payload
-        return self._payload[:amt]
+    def read(self) -> bytes:
+        return self._payload
 
     def close(self) -> None:
         self.closed = True

--- a/tests/test_s3_async.py
+++ b/tests/test_s3_async.py
@@ -130,6 +130,59 @@ async def test_async_client_streaming_body_iteration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_body_context_manager_rejects_sized_read() -> None:
+    with mock_aws():
+        s3_sync = boto3.client("s3", region_name=AWS_REGION)
+        s3_sync.create_bucket(Bucket="ctx-bucket")
+
+        async with AioSession().create_client("s3", region_name=AWS_REGION) as s3_async:
+            await s3_async.put_object(
+                Bucket="ctx-bucket", Key="ctx-key", Body=b"y" * 4096
+            )
+
+            resp = await s3_async.get_object(Bucket="ctx-bucket", Key="ctx-key")
+            with pytest.raises(TypeError):
+                async with resp["Body"] as stream:
+                    await stream.read(1024)
+
+            resp = await s3_async.get_object(Bucket="ctx-bucket", Key="ctx-key")
+            async with resp["Body"] as stream:
+                assert await stream.read() == b"y" * 4096
+
+            resp = await s3_async.get_object(Bucket="ctx-bucket", Key="ctx-key")
+            async with resp["Body"] as stream:
+                assert await stream.content.read(1024) == b"y" * 1024
+
+
+@pytest.mark.asyncio
+async def test_object_state_persists_across_repeated_reads() -> None:
+    with mock_aws():
+        async with AioSession().create_client("s3", region_name=AWS_REGION) as s3_async:
+            await s3_async.create_bucket(Bucket="persist-bucket")
+            await s3_async.put_object(
+                Bucket="persist-bucket", Key="persist-key", Body=b"hello world"
+            )
+
+            first = await s3_async.get_object(
+                Bucket="persist-bucket", Key="persist-key"
+            )
+            assert await first["Body"].read() == b"hello world"
+
+            second = await s3_async.get_object(
+                Bucket="persist-bucket", Key="persist-key"
+            )
+            assert await second["Body"].read() == b"hello world"
+
+            partial = await s3_async.get_object(
+                Bucket="persist-bucket", Key="persist-key"
+            )
+            body = partial["Body"]
+            assert await body.read(5) == b"hello"
+            assert await body.read(6) == b" world"
+            assert await body.read(1) == b""
+
+
+@pytest.mark.asyncio
 async def test_async_client_listing_preserves_key_names() -> None:
     with mock_aws():
         s3_sync = boto3.client("s3", region_name=AWS_REGION)

--- a/tests/test_s3_async.py
+++ b/tests/test_s3_async.py
@@ -147,11 +147,13 @@ async def test_streaming_body_context_manager_rejects_sized_read() -> None:
 
             resp = await s3_async.get_object(Bucket="ctx-bucket", Key="ctx-key")
             async with resp["Body"] as stream:
-                assert await stream.read() == b"y" * 4096
+                partial = await stream.content.read(1024)
+            assert partial == b"y" * 1024
 
             resp = await s3_async.get_object(Bucket="ctx-bucket", Key="ctx-key")
             async with resp["Body"] as stream:
-                assert await stream.content.read(1024) == b"y" * 1024
+                full = await stream.read()
+            assert full == b"y" * 4096
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "aiomoto"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
## Summary

Fixes #106.

`_AioBytesIOAdapter` plays the role of the `aiohttp.ClientResponse` that aiobotocore's `StreamingBody` wraps (`http_response.raw`). It conflated two distinct roles into a single `read(amt)`:

- **`ClientResponse.read()`** — takes **no** size argument.
- **`ClientResponse.content` (a `StreamReader`) `read(n)`** — takes a size, because `StreamingBody.read(amt)` delegates to `raw.content.read(amt)`.

Because `content = self` and the single `read` accepted `amt`, the misuse `async with body as stream: await stream.read(amt)` silently worked here even though it `TypeError`s against real S3 (`aiohttp.ClientResponse.read()` takes no positional arg).

## Change

- Split the `StreamReader` role into a new `_AioStreamReader` (`read(n=-1)`, exposed as `adapter.content`).
- `_AioBytesIOAdapter.read()` now takes **no** size argument, faithfully mirroring `aiohttp.ClientResponse.read()`. `__aenter__` still returns `self`, matching `ClientResponse.__aenter__`.

Behaviour now matches real aiobotocore:

| Usage | Before | After |
|---|---|---|
| `body.read(amt)` | ✅ | ✅ |
| `iter_chunks` / `iter_lines` | ✅ | ✅ |
| `async with body as stream: await stream.read(amt)` | passed (masked bug) | **`TypeError`** (matches real S3) |
| `async with body as stream: await stream.read()` | ✅ | ✅ |
| `await stream.content.read(amt)` | ✅ | ✅ |

State persistence within a `mock_aws()` context is unchanged and confirmed: objects round-trip, the same object can be downloaded repeatedly (full content each time), and partial reads consume the stream as expected.

## Tests

- Updated `tests/patches/test_core_internal.py` for the split design + a guard that `adapter.read(2)` raises while `adapter.content.read(...)` works.
- Added two end-to-end S3 tests in `tests/test_s3_async.py` (context-manager misuse rejection; repeated/partial-read persistence).
- `core.py` at 100% branch coverage; full suite (202 tests) passes; `prek run --all-files` and `ty` clean.

Patch version bumped to `0.5.1`.