### PR TITLE
docs: add Zensical documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Zensical documentation build output
+/site/

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,6 +1,6 @@
 line-length = 88
 disable = []
-exclude = ["CLAUDE.md"]
+exclude = ["CLAUDE.md", "docs/**"]
 respect-gitignore = true
 
 [MD004]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ focus is a clean, reusable library API rather than a CLI entry point.
 - **/src/aiomoto/** – Library code.
 - **/tests/** – Pytest suite kept in sync with the src layout; module names mirror
   the src module they cover and use the `test_` prefix.
-- **Wiki** – <https://github.com/owenlamont/aiomoto/wiki> (roadmap, etc.). Keep wiki
-  pages in sync when behaviour changes.
+- **/docs/** – Zensical documentation source (Markdown). Built output goes to
+  `/site/` (gitignored). This is the canonical project documentation, published at
+  <https://aiomoto-docs.pages.dev/>.
 - **.complexipy.toml** – Complexipy configuration.
 - **.coveragerc** – Coverage path mappings.
 - **ty.toml** – ty type checker configuration.
@@ -44,6 +45,22 @@ focus is a clean, reusable library API rather than a CLI entry point.
 - **.rumdl.toml** – Markdown linter configuration.
 - **.ryl.toml** – YAML linter configuration.
 - **typos.toml** – Typos configuration.
+- **zensical.toml** – Documentation site configuration.
+
+## Documentation Site
+
+- The Zensical documentation source lives under `/docs/` with site configuration in
+  `zensical.toml`. Built output goes to `/site/` (gitignored).
+- Zensical is pinned via the `docs` dependency group in `pyproject.toml` and locked
+  in `uv.lock`. Use the uv group commands so transitive deps stay in sync with the
+  lockfile.
+- Build the site: `uv run --group docs zensical build --clean`.
+- Preview locally with live reload: `uv run --group docs zensical serve`.
+- Bumping Zensical: edit the pin in `pyproject.toml`, run `uv lock`, then rebuild to
+  confirm the new version still renders cleanly.
+- `docs/**` is excluded from `rumdl` (the docs use Zensical/Material Markdown
+  extensions rumdl does not understand), so keep prose readable but don't expect the
+  Markdown linter to cover it.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ botocore / boto3). It adapts Moto's stubber so async and sync clients share the 
 in-memory backend: you can write to a mock S3 bucket with boto3 and read it back via
 aiobotocore in the same process.
 
+📖 **Full documentation: <https://aiomoto-docs.pages.dev/>**
+
 ## Supported today
 
 - `mock_aws()` usable as `with` or `async with`, guarding against real HTTP requests.
@@ -16,291 +18,67 @@ aiobotocore in the same process.
   hit a service-specific gap, open an issue with a minimal repro so we can add a
   focused slice.
 
-For the evolving project roadmap, see the wiki: <https://github.com/owenlamont/aiomoto/wiki/Roadmap>
-
-## Motivation
-
-Like many others I've wanted to use Moto with aiobotocore but found that
-wasn't supported, see:
-
-- <https://github.com/getmoto/moto/issues/2039>
-- <https://github.com/getmoto/moto/issues/8694>
-
-The primary motivation for attempting to create an aiomoto repo came from this issue
-<https://github.com/getmoto/moto/issues/8513>
-which states aiobotocore support is out of scope for moto and the current primary moto
-maintainer suggested creating an aiomoto repo.
-
-## Related Work
-
-<https://github.com/dazza-codes/pytest-aiomoto> was an earlier attempt at this but not
-really maintained now.
-
-There is discussion on aiobotocore repo about moto support here
-<https://github.com/aio-libs/aiobotocore/discussions/1300>
-
-Both the above approaches as far as I'm aware rely on the Moto's
-[server mode](https://docs.getmoto.org/en/latest/docs/server_mode.html) which I don't
-want to use (mainly as I found server mode was slower than other local AWS services
-like dynamodb-local in-memory and I also wanted to run tests in parallel without
-worrying about port clashes or race conditions). In short I don't want any server and I
-want aiomoto to support the moto like mock contexts in the same thread / process as the
-tests run in.
-
 ## Installation
 
 ```bash
 pip install aiomoto
 ```
 
-aiomoto exposes the same Moto service extras, so you can install Moto plus the
-dependencies required for the specific AWS services you use (for example
-`aiomoto[s3]`, `aiomoto[dynamodb]`, or `aiomoto[all]`). Moto's extras are
-service selectors for dependency sets (use `moto[all]` if you want everything),
-rather than features provided by aiomoto itself. See the Moto install guide:
-[Moto install guide](https://docs.getmoto.org/en/latest/docs/getting_started.html)
-
-aiomoto-specific extras like `pandas` and `polars` behave like standard optional
-dependencies, adding those libraries and their support stack on top of Moto.
-
-Server mode requires Moto's server extra:
-
-```bash
-pip install "aiomoto[server]"
-```
-
-Pandas and Polars integrations are optional extras that add their own
-dependencies:
-
-```bash
-pip install "aiomoto[pandas]"
-pip install "aiomoto[polars]"
-```
+aiomoto re-exposes Moto's service extras (for example `aiomoto[s3]`,
+`aiomoto[dynamodb]`, or `aiomoto[all]`), plus aiomoto-specific extras
+(`aiomoto[server]`, `aiomoto[pandas]`, `aiomoto[polars]`). See the
+[installation guide](https://aiomoto-docs.pages.dev/getting-started/installation/)
+for details.
 
 ## Usage
 
 Use `aiomoto.mock_aws` as a drop-in replacement for Moto's `mock_aws` that works
-with both synchronous boto3/botocore clients and asynchronous aiobotocore
-clients in the same process. It supports `with` and `async with` (and can decorate
-sync/async callables).
-
-### Use as a decorator
-
-Use `@mock_aws` as a decorator when you want Moto started/stopped for the span of
-a test function. Both sync and async callables are supported; omit parentheses
-when you are not passing arguments (they remain optional to match Moto’s examples).
-`mock_aws_decorator`
-is also exported for teams that prefer an explicitly decorator-only name (or want
-to preconfigure `reset` / `remove_data` once and reuse it) while leaving `mock_aws`
-for context-manager usage.
-
-```python
-import boto3
-from aiobotocore.session import AioSession
-from aiomoto import mock_aws, mock_aws_decorator
-
-
-@mock_aws
-def test_sync_bucket() -> None:
-    client = boto3.client("s3", region_name="us-east-1")
-    client.create_bucket(Bucket="decorator-demo")
-
-
-@mock_aws_decorator
-async def test_async_bucket() -> None:
-    async with AioSession().create_client("s3", region_name="us-east-1") as client:
-        await client.create_bucket(Bucket="decorator-demo")
-```
-
-### Use as a context manager
+with both synchronous boto3/botocore clients and asynchronous aiobotocore clients in
+the same process. It supports `with`, `async with`, and decorating sync/async
+callables.
 
 ```python
 import boto3
 from aiobotocore.session import AioSession
 from aiomoto import mock_aws
 
-async def demo():
-    async with mock_aws():
-        s3_sync = boto3.client("s3", region_name="us-east-1")
-        s3_sync.create_bucket(Bucket="example")
 
+async def demo() -> None:
+    async with mock_aws():
+        # Write with a synchronous boto3 client.
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="example")
+
+        # Read it back with an async aiobotocore client.
         session = AioSession()
-        async with session.create_client("s3", region_name="us-east-1") as s3_async:
-            result = await s3_async.list_buckets()
+        async with session.create_client("s3", region_name="us-east-1") as s3:
+            result = await s3.list_buckets()
             assert any(b["Name"] == "example" for b in result["Buckets"])
 ```
 
-While aiomoto is active in in-process mode it prevents aiobotocore from issuing real
-HTTP calls; any attempts fall back to Moto and will raise if they escape the
-stubber. Avoid mixing raw Moto decorators with aiomoto contexts in the same test to
-keep state aligned.
+The documentation covers more:
 
-In-process mode inherits Moto's URL matching behavior. Ambient endpoint
-configuration such as `AWS_ENDPOINT_URL=http://localhost:4566` can make boto3 or
-aiobotocore clients target that endpoint instead of a normal AWS service URL, which
-means Moto will not intercept the request. If your environment sets
-`AWS_ENDPOINT_URL`, either unset it for in-process tests or set
-`AWS_IGNORE_CONFIGURED_ENDPOINT_URLS=true` so botocore ignores configured endpoint
-URLs. If you intentionally need clients to use a local HTTP endpoint, prefer
-`mock_aws(server_mode=True)`.
+- [Contexts and decorators](https://aiomoto-docs.pages.dev/guides/contexts-and-decorators/)
+  — `with` / `async with`, `@mock_aws`, `reset` / `remove_data`, and the
+  `AWS_ENDPOINT_URL` gotcha.
+- [Server mode](https://aiomoto-docs.pages.dev/guides/server-mode/) — run a local
+  Moto server, endpoint-injection modes, and attaching to an existing server.
+- [Pandas and Polars](https://aiomoto-docs.pages.dev/guides/dataframes/) — `s3://`
+  DataFrame I/O.
+- [Examples](https://aiomoto-docs.pages.dev/examples/) — S3, DynamoDB, SQS, SNS,
+  s3fs, and streaming reads.
+- [API reference](https://aiomoto-docs.pages.dev/reference/api/) — `mock_aws`,
+  `mock_aws_decorator`, `AutoEndpointMode`, and the exception types.
 
-> aiomoto defaults to Moto’s **in-process** mode. Use
-> `mock_aws(server_mode=True)` to run a local Moto server without in-process
-> patches. In server mode, set `auto_endpoint` to control endpoint injection:
-> `force` (default), `if_missing`, or `disabled`. Moto proxy mode remains
-> unsupported. Server mode needs `moto[server]` installed.
->
-> Server mode is typically slower than in-process mode, but it enables
-> compatibility with Pandas and Polars S3 I/O (and other tooling that expects a
-> real endpoint).
+## Motivation
 
-Server mode can also attach to an existing server by passing a `server_port`.
-This keeps the context in “client mode” (no server start/stop) while still
-injecting the endpoint. When aiomoto starts a server it records a registry file
-under `AIOMOTO_SERVER_REGISTRY_DIR` and exposes the path via
-`ctx.server_registry_path`.
-
-Registry files use the pattern
-`${AIOMOTO_SERVER_REGISTRY_DIR}/aiomoto-server-<uuid>.json`
-and contain payloads like:
-
-```json
-{
-  "endpoint": "http://127.0.0.1:12345",
-  "host": "127.0.0.1",
-  "pid": 1234,
-  "port": 12345
-}
-```
-
-Registry entries older than 24 hours are treated as stale and cleaned up when a
-new server is started.
-
-### Server mode example
-
-```python
-import boto3
-from aiomoto import AutoEndpointMode, mock_aws
-
-
-def test_server_mode_force() -> None:
-    with mock_aws(server_mode=True) as ctx:
-        client = boto3.client("s3")
-        assert client.meta.endpoint_url == ctx.server_endpoint
-        client.create_bucket(Bucket="server-mode")
-
-
-def test_server_mode_if_missing() -> None:
-    with mock_aws(server_mode=True, auto_endpoint=AutoEndpointMode.IF_MISSING):
-        client = boto3.client("s3", endpoint_url="http://example.com")
-        assert client.meta.endpoint_url == "http://example.com"
-
-
-def test_server_mode_disabled() -> None:
-    with mock_aws(server_mode=True, auto_endpoint=AutoEndpointMode.DISABLED) as ctx:
-        client = boto3.client("s3", endpoint_url=ctx.server_endpoint)
-        client.create_bucket(Bucket="server-mode-explicit")
-
-
-def test_server_mode_attach() -> None:
-    with mock_aws(server_mode=True) as server:
-        port = server.server_port
-        assert port is not None
-        # In another process, pass server_port to reuse the existing server.
-        with mock_aws(server_mode=True, server_port=port) as client:
-            assert client.server_endpoint == server.server_endpoint
-```
-
-### Pandas S3 in server mode
-
-```python
-import boto3
-import pandas as pd
-from aiomoto import mock_aws
-
-
-def test_pandas_server_mode_csv() -> None:
-    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-    path = "s3://pandas-bucket/data.csv"
-
-    with mock_aws(server_mode=True):
-        boto3.client("s3").create_bucket(Bucket="pandas-bucket")
-        # aiomoto patches pandas + fsspec/s3fs so s3:// routes to Moto.
-        df.to_csv(path, index=False)
-        result = pd.read_csv(path)
-
-    assert result.equals(df)
-```
-
-Requires pandas + fsspec + s3fs for S3 access (pyarrow for parquet). You can
-install the pandas extra via `aiomoto[pandas]`.
-
-### s3fs example
-
-```python
-import s3fs
-from aiomoto import mock_aws
-
-
-def test_s3fs_sync_usage() -> None:
-    with mock_aws():
-        fs = s3fs.S3FileSystem(asynchronous=False, anon=False)
-        fs.call_s3("create_bucket", Bucket="bucket-123")
-        fs.call_s3("put_object", Bucket="bucket-123", Key="test.txt", Body=b"hi")
-        assert fs.cat("bucket-123/test.txt") == b"hi"
-```
-
-### DynamoDB example
-
-```python
-import boto3
-from aiobotocore.session import AioSession
-from aiomoto import mock_aws
-
-AWS_REGION = "us-west-2"
-
-async def demo():
-    with mock_aws():
-        # Sync write
-        ddb_sync = boto3.client("dynamodb", region_name=AWS_REGION)
-        ddb_sync.create_table(
-            TableName="items",
-            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
-            BillingMode="PAY_PER_REQUEST",
-        )
-        ddb_sync.put_item(TableName="items", Item={"pk": {"S": "from-sync"}})
-
-        # Async read (aiobotocore)
-        async with AioSession().create_client(
-            "dynamodb", region_name=AWS_REGION
-        ) as ddb_async:
-            item = await ddb_async.get_item(
-                TableName="items", Key={"pk": {"S": "from-sync"}}
-            )
-            assert item["Item"]["pk"]["S"] == "from-sync"
-```
-
-## Roadmap
-
-The living roadmap sits in the wiki [Roadmap](https://github.com/owenlamont/aiomoto/wiki/Roadmap)
+Like many others I've wanted to use Moto with aiobotocore but found that wasn't
+supported. The
+[motivation page](https://aiomoto-docs.pages.dev/about/motivation/) explains the
+background and why aiomoto avoids depending on Moto's server mode by default.
 
 ## Limitations
 
-- Mixing raw Moto decorators with `aiomoto.mock_aws` in the same test is unsupported;
-  the contexts manage shared state differently and can diverge.
-- aiomoto wraps moto and patches aiobotocore; s3fs should be covered automatically
-  as it uses aiobotocore clients underneath.
-- We keep version ranges narrow and tested together, if you notice a new version of
-  aiobotocore or moto that doesn't get covered feel free to raise an issue for this.
-- s3fs caches filesystem instances; create them inside `mock_aws` and close them so
-  finalizers don’t hit a closed or different event loop.
-- Pandas S3 I/O: in server mode, aiomoto patches pandas to route `s3://` through
-  fsspec/s3fs when those dependencies are installed.
-- Polars S3 I/O is patched in server mode when polars is installed; aiomoto
-  injects `storage_options` for `s3://` paths following the `auto_endpoint` mode.
-- Free-threaded CPython 3.14t support covers aiomoto's core in-process mocking.
-  Pandas and Polars server-mode integrations are validated on regular CPython
-  builds only; their dependency stacks are not yet reliable on free-threaded
-  interpreters, and Windows 3.14t also lacks compatible pywin32 wheels for
-  Moto's server dependency chain.
+aiomoto keeps version ranges narrow and tested together, and a few integrations
+(notably pandas/polars S3 I/O) only work in server mode. See the
+[limitations page](https://aiomoto-docs.pages.dev/about/limitations/) for the full
+list, including free-threaded CPython support.

--- a/docs/about/limitations.md
+++ b/docs/about/limitations.md
@@ -1,0 +1,24 @@
+# Limitations
+
+- Mixing raw Moto decorators with `aiomoto.mock_aws` in the same test is
+  unsupported; the contexts manage shared state differently and can diverge.
+- aiomoto wraps Moto and patches aiobotocore; s3fs should be covered automatically
+  in in-process mode since it uses aiobotocore clients underneath.
+- Version ranges are kept narrow and tested together. If you notice a new version of
+  aiobotocore or Moto that isn't covered, please
+  [raise an issue](https://github.com/owenlamont/aiomoto/issues).
+- s3fs caches filesystem instances; create them inside `mock_aws` and close them so
+  finalizers don't run against a closed or different event loop.
+- Pandas S3 I/O: in server mode, aiomoto patches pandas to route `s3://` through
+  fsspec/s3fs when those dependencies are installed.
+- Polars S3 I/O is patched in server mode when polars is installed; aiomoto injects
+  `storage_options` for `s3://` paths following the `auto_endpoint` mode.
+- Moto proxy mode is unsupported; requesting it raises `ProxyModeError`.
+
+## Free-threaded CPython
+
+Free-threaded CPython 3.14t support covers aiomoto's core in-process mocking. The
+pandas and polars server-mode integrations are validated on regular CPython builds
+only &mdash; their dependency stacks are not yet reliable on free-threaded
+interpreters, and Windows 3.14t also lacks compatible pywin32 wheels for Moto's
+server dependency chain.

--- a/docs/about/motivation.md
+++ b/docs/about/motivation.md
@@ -1,0 +1,37 @@
+# Motivation
+
+Like many others I wanted to use Moto with aiobotocore but found that wasn't
+supported. See:
+
+- [getmoto/moto#2039](https://github.com/getmoto/moto/issues/2039)
+- [getmoto/moto#8694](https://github.com/getmoto/moto/issues/8694)
+
+The primary motivation for creating aiomoto came from
+[getmoto/moto#8513](https://github.com/getmoto/moto/issues/8513), which states that
+aiobotocore support is out of scope for Moto, and the current primary Moto
+maintainer suggested creating an aiomoto repo.
+
+## Why in-process by default?
+
+[pytest-aiomoto](https://github.com/dazza-codes/pytest-aiomoto) was an earlier
+attempt at this but is not really maintained now. There is also discussion on the
+aiobotocore repo about Moto support in
+[aio-libs/aiobotocore#1300](https://github.com/aio-libs/aiobotocore/discussions/1300).
+
+As far as I'm aware, both of those approaches rely on Moto's
+[server mode](https://docs.getmoto.org/en/latest/docs/server_mode.html). aiomoto
+makes in-process mode the default instead, for one reason: **speed**. In-process
+mocking avoids the cost of spinning a Moto server up and down, which is also slower
+than other local AWS services such as in-memory dynamodb-local. So the default mode
+needs no server at all &mdash; aiomoto runs Moto-style mock contexts in the same
+thread / process the tests run in.
+
+[Server mode](../guides/server-mode.md) is still supported as an opt-in for the
+cases that genuinely need a real HTTP endpoint &mdash; notably pandas / polars S3
+I/O and other tooling that expects an endpoint.
+
+Both modes are safe under parallel test runners such as
+[pytest-xdist](https://pytest-xdist.readthedocs.io/): each worker is a separate
+process, so server mode starts one Moto server per worker on an OS-assigned
+ephemeral port with a fully isolated backend &mdash; no port clashes and no shared
+state. Speed is the only reason to reach for in-process mode over server mode.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,129 @@
+# Examples
+
+These examples all use in-process mode (the default). Each one shows the aiomoto
+signature: a single Moto backend shared between synchronous boto3 clients and
+asynchronous aiobotocore clients.
+
+## S3: write sync, read async
+
+```python
+import boto3
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        s3_sync = boto3.client("s3", region_name="us-east-1")
+        s3_sync.create_bucket(Bucket="example")
+        s3_sync.put_object(Bucket="example", Key="hello.txt", Body=b"hi")
+
+        session = AioSession()
+        async with session.create_client("s3", region_name="us-east-1") as s3_async:
+            response = await s3_async.get_object(Bucket="example", Key="hello.txt")
+            async with response["Body"] as stream:
+                assert await stream.read() == b"hi"
+```
+
+The streaming `Body` is an async context manager that mirrors aiohttp's
+`ClientResponse`, so `async with` and `await stream.read()` work as expected.
+
+## DynamoDB
+
+```python
+import boto3
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+AWS_REGION = "us-west-2"
+
+
+async def demo() -> None:
+    with mock_aws():
+        # Sync write.
+        ddb_sync = boto3.client("dynamodb", region_name=AWS_REGION)
+        ddb_sync.create_table(
+            TableName="items",
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        ddb_sync.put_item(TableName="items", Item={"pk": {"S": "from-sync"}})
+
+        # Async read (aiobotocore).
+        async with AioSession().create_client(
+            "dynamodb", region_name=AWS_REGION
+        ) as ddb_async:
+            item = await ddb_async.get_item(
+                TableName="items", Key={"pk": {"S": "from-sync"}}
+            )
+            assert item["Item"]["pk"]["S"] == "from-sync"
+```
+
+## SQS
+
+```python
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        async with AioSession().create_client("sqs", region_name="us-east-1") as sqs:
+            queue = await sqs.create_queue(QueueName="jobs")
+            url = queue["QueueUrl"]
+            await sqs.send_message(QueueUrl=url, MessageBody="ping")
+            received = await sqs.receive_message(QueueUrl=url)
+            assert received["Messages"][0]["Body"] == "ping"
+```
+
+## SNS
+
+```python
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        async with AioSession().create_client("sns", region_name="us-east-1") as sns:
+            topic = await sns.create_topic(Name="alerts")
+            await sns.publish(TopicArn=topic["TopicArn"], Message="hello")
+```
+
+## Secrets Manager
+
+```python
+import boto3
+from aiomoto import mock_aws
+
+
+def test_secrets() -> None:
+    with mock_aws():
+        client = boto3.client("secretsmanager", region_name="us-east-1")
+        client.create_secret(Name="token", SecretString="s3cr3t")
+        assert client.get_secret_value(SecretId="token")["SecretString"] == "s3cr3t"
+```
+
+## s3fs
+
+s3fs runs on aiobotocore under the hood, so it works in in-process mode:
+
+```python
+import s3fs
+from aiomoto import mock_aws
+
+
+def test_s3fs() -> None:
+    with mock_aws():
+        fs = s3fs.S3FileSystem(asynchronous=False, anon=False)
+        fs.call_s3("create_bucket", Bucket="bucket-123")
+        fs.call_s3("put_object", Bucket="bucket-123", Key="test.txt", Body=b"hi")
+        assert fs.cat("bucket-123/test.txt") == b"hi"
+```
+
+## More
+
+- [Server mode](guides/server-mode.md) examples for force / if-missing / disabled
+  endpoint injection and attaching to an existing server.
+- [Pandas and Polars](guides/dataframes.md) for `s3://` DataFrame I/O.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,8 +48,8 @@ pip install "aiomoto[server]"
 
 ## Pandas and Polars
 
-The `pandas` and `polars` integrations add the DataFrame library and Moto's server
-extra (server mode is required for `s3://` I/O):
+These integrations bundle everything needed for `s3://` DataFrame I/O, which always
+runs through [server mode](../guides/server-mode.md):
 
 === "Pandas"
 
@@ -57,11 +57,17 @@ extra (server mode is required for `s3://` I/O):
     pip install "aiomoto[pandas]"
     ```
 
+    Pulls in pandas, Moto's server extra, and the S3 stack (`fsspec`, `s3fs`, and
+    `pyarrow` for parquet).
+
 === "Polars"
 
     ```bash
     pip install "aiomoto[polars]"
     ```
+
+    Pulls in polars and Moto's server extra; polars reads `s3://` through its
+    native object-store layer.
 
 See [Pandas and Polars](../guides/dataframes.md) for how `s3://` paths are routed
 through Moto.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,77 @@
+# Installation
+
+aiomoto is published on PyPI:
+
+```bash
+pip install aiomoto
+```
+
+It requires Python 3.11 or newer and pulls in `aiobotocore`, `moto`, and
+`platformdirs`.
+
+## Service extras
+
+aiomoto re-exposes Moto's service extras, so you can install Moto plus the
+dependencies required for the specific AWS services you use:
+
+=== "S3"
+
+    ```bash
+    pip install "aiomoto[s3]"
+    ```
+
+=== "DynamoDB"
+
+    ```bash
+    pip install "aiomoto[dynamodb]"
+    ```
+
+=== "Everything"
+
+    ```bash
+    pip install "aiomoto[all]"
+    ```
+
+Moto's extras are service selectors for dependency sets (use `all` if you want
+everything) rather than features provided by aiomoto itself. See the
+[Moto install guide](https://docs.getmoto.org/en/latest/docs/getting_started.html)
+for the full list.
+
+## Server mode
+
+[Server mode](../guides/server-mode.md) runs a local Moto server instead of
+patching in process. It needs Moto's `server` extra:
+
+```bash
+pip install "aiomoto[server]"
+```
+
+## Pandas and Polars
+
+The `pandas` and `polars` integrations add the DataFrame library and Moto's server
+extra (server mode is required for `s3://` I/O):
+
+=== "Pandas"
+
+    ```bash
+    pip install "aiomoto[pandas]"
+    ```
+
+=== "Polars"
+
+    ```bash
+    pip install "aiomoto[polars]"
+    ```
+
+See [Pandas and Polars](../guides/dataframes.md) for how `s3://` paths are routed
+through Moto.
+
+## Verify the install
+
+```python
+import aiomoto
+
+print(aiomoto.__version__)
+```
+
+Continue to the [Quick start](quickstart.md) to mock your first AWS service.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,82 @@
+# Quick start
+
+`aiomoto.mock_aws` is a drop-in replacement for Moto's `mock_aws` that works with
+both synchronous boto3/botocore clients and asynchronous aiobotocore clients in the
+same process. It supports `with`, `async with`, and decorating sync or async
+callables.
+
+## As a context manager
+
+The defining feature of aiomoto is that one Moto backend is shared across sync and
+async clients. Write with boto3, read with aiobotocore:
+
+```python
+import boto3
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        s3_sync = boto3.client("s3", region_name="us-east-1")
+        s3_sync.create_bucket(Bucket="example")
+
+        session = AioSession()
+        async with session.create_client("s3", region_name="us-east-1") as s3_async:
+            result = await s3_async.list_buckets()
+            assert any(b["Name"] == "example" for b in result["Buckets"])
+```
+
+A plain `with mock_aws():` block works too when you only need synchronous clients.
+
+## As a decorator
+
+Use `@mock_aws` as a decorator to start and stop Moto for the span of a test
+function. Both sync and async callables are supported; the parentheses are optional:
+
+```python
+import boto3
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+@mock_aws
+def test_sync_bucket() -> None:
+    client = boto3.client("s3", region_name="us-east-1")
+    client.create_bucket(Bucket="decorator-demo")
+
+
+@mock_aws
+async def test_async_bucket() -> None:
+    async with AioSession().create_client("s3", region_name="us-east-1") as client:
+        await client.create_bucket(Bucket="decorator-demo")
+```
+
+!!! tip "Prefer an explicit decorator name?"
+
+    `mock_aws_decorator` is also exported for teams that want an explicitly
+    decorator-only name, or that want to preconfigure `reset` / `remove_data` once
+    and reuse it, while leaving `mock_aws` for context-manager usage. See
+    [Contexts and decorators](../guides/contexts-and-decorators.md).
+
+## Blocking real requests
+
+While aiomoto is active in in-process mode it prevents aiobotocore from issuing real
+HTTP calls; any attempt that escapes the stubber raises
+[`RealHTTPRequestBlockedError`](../reference/api.md#exceptions). This keeps tests
+hermetic &mdash; a call to an unmocked endpoint fails loudly instead of reaching the
+real internet.
+
+!!! warning "Don't mix raw Moto decorators with aiomoto"
+
+    Avoid mixing raw Moto decorators with aiomoto contexts in the same test. The
+    two manage shared state differently and can diverge.
+
+## Next steps
+
+- [Contexts and decorators](../guides/contexts-and-decorators.md) &mdash; reset and
+  data-removal options, nesting, and the `AWS_ENDPOINT_URL` gotcha.
+- [Server mode](../guides/server-mode.md) &mdash; run a real local Moto server when
+  you need an HTTP endpoint.
+- [Examples](../examples.md) &mdash; S3, DynamoDB, SQS, SNS, s3fs, and streaming
+  reads.

--- a/docs/guides/contexts-and-decorators.md
+++ b/docs/guides/contexts-and-decorators.md
@@ -1,0 +1,104 @@
+# Contexts and decorators
+
+`mock_aws` is a single callable that adapts to how you use it: as a context manager
+(`with` / `async with`) or as a decorator over a sync or async function.
+
+## Context manager
+
+```python
+import boto3
+from aiomoto import mock_aws
+
+
+def test_with_block() -> None:
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="demo")
+```
+
+The same object supports `async with`, which is required when the body needs an
+event loop (for example when using aiobotocore clients):
+
+```python
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        async with AioSession().create_client("s3", region_name="us-east-1") as s3:
+            await s3.create_bucket(Bucket="demo")
+```
+
+## Decorator
+
+`@mock_aws` starts Moto before the wrapped function runs and stops it afterwards.
+Omit the parentheses when you are not passing arguments (they remain optional to
+match Moto's examples):
+
+```python
+from aiomoto import mock_aws
+
+
+@mock_aws
+def test_sync() -> None: ...
+
+
+@mock_aws(reset=False)
+def test_sync_no_reset() -> None: ...
+```
+
+### `mock_aws_decorator`
+
+`mock_aws_decorator` is exported for teams that prefer an explicitly decorator-only
+name, or that want to preconfigure options once and reuse them:
+
+```python
+from aiomoto import mock_aws_decorator
+
+
+# Preconfigure once, reuse as a decorator.
+mock_no_reset = mock_aws_decorator(reset=False, remove_data=False)
+
+
+@mock_no_reset
+async def test_async() -> None: ...
+```
+
+Calling `mock_aws_decorator(...)` with keyword arguments returns a reusable
+context/decorator instance; calling it directly on a function (`@mock_aws_decorator`)
+wraps that function with the defaults.
+
+## Reset and data removal
+
+Both `mock_aws` and `mock_aws_decorator` accept `reset` and `remove_data` (each
+defaulting to `True`):
+
+| Parameter     | Default | Effect                                                        |
+| ------------- | ------- | ------------------------------------------------------------- |
+| `reset`       | `True`  | Reset Moto's backends when the context starts.                |
+| `remove_data` | `True`  | Remove backend data when the context exits.                   |
+
+Leaving both at their defaults gives each test an isolated, empty AWS environment.
+
+## Nesting
+
+Contexts are re-entrant: entering an already-active context simply increases an
+internal depth counter, and the backend is only torn down when the outermost
+context exits. This makes it safe to combine a decorator with an inner `with
+mock_aws():` block without losing state.
+
+## The `AWS_ENDPOINT_URL` gotcha
+
+In-process mode inherits Moto's URL-matching behaviour. Ambient endpoint
+configuration such as `AWS_ENDPOINT_URL=http://localhost:4566` can make boto3 or
+aiobotocore target that endpoint instead of a normal AWS service URL, which means
+Moto will not intercept the request.
+
+If your environment sets `AWS_ENDPOINT_URL`:
+
+- Unset it for in-process tests, **or**
+- Set `AWS_IGNORE_CONFIGURED_ENDPOINT_URLS=true` so botocore ignores configured
+  endpoint URLs.
+
+If you intentionally need clients to use a local HTTP endpoint, prefer
+[server mode](server-mode.md) instead.

--- a/docs/guides/dataframes.md
+++ b/docs/guides/dataframes.md
@@ -13,9 +13,9 @@ to the local Moto server.
 
 ## Pandas
 
-`aiomoto[pandas]` installs pandas and Moto's server extra. With server mode active,
-aiomoto patches pandas + fsspec/s3fs so `s3://` paths reach Moto. For S3 access you
-also need fsspec + s3fs (and pyarrow for parquet):
+`aiomoto[pandas]` installs pandas, Moto's server extra, and the S3 stack (`fsspec`,
+`s3fs`, and `pyarrow` for parquet). With server mode active, aiomoto patches
+pandas + fsspec/s3fs so `s3://` paths reach Moto:
 
 ```python
 import boto3
@@ -35,7 +35,9 @@ def test_pandas_server_mode_csv() -> None:
     assert result.equals(df)
 ```
 
-Requires pandas + fsspec + s3fs for S3 access (and pyarrow for parquet).
+aiomoto only patches pandas when `fsspec` and `s3fs` are both importable; the
+`aiomoto[pandas]` extra installs both (plus `pyarrow` for parquet), so the
+integration is active out of the box.
 
 ## Polars
 

--- a/docs/guides/dataframes.md
+++ b/docs/guides/dataframes.md
@@ -1,0 +1,84 @@
+# Pandas and Polars
+
+pandas and polars read and write `s3://` paths through fsspec/s3fs and their own
+object-store layers, which expect a real HTTP endpoint. aiomoto wires these up in
+[server mode](server-mode.md): it patches the DataFrame libraries so `s3://` routes
+to the local Moto server.
+
+!!! note "Server mode required"
+
+    DataFrame S3 I/O is patched only in server mode, because the underlying
+    libraries need a real endpoint. Install the relevant extra
+    (`aiomoto[pandas]` or `aiomoto[polars]`) so the dependencies are present.
+
+## Pandas
+
+`aiomoto[pandas]` installs pandas and Moto's server extra. With server mode active,
+aiomoto patches pandas + fsspec/s3fs so `s3://` paths reach Moto. For S3 access you
+also need fsspec + s3fs (and pyarrow for parquet):
+
+```python
+import boto3
+import pandas as pd
+from aiomoto import mock_aws
+
+
+def test_pandas_server_mode_csv() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    path = "s3://pandas-bucket/data.csv"
+
+    with mock_aws(server_mode=True):
+        boto3.client("s3").create_bucket(Bucket="pandas-bucket")
+        df.to_csv(path, index=False)
+        result = pd.read_csv(path)
+
+    assert result.equals(df)
+```
+
+Requires pandas + fsspec + s3fs for S3 access (and pyarrow for parquet).
+
+## Polars
+
+`aiomoto[polars]` installs polars and Moto's server extra. In server mode aiomoto
+injects `storage_options` for `s3://` paths, following the `auto_endpoint` mode:
+
+```python
+import boto3
+import polars as pl
+from aiomoto import mock_aws
+
+
+def test_polars_server_mode_parquet() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    path = "s3://polars-bucket/data.parquet"
+
+    with mock_aws(server_mode=True):
+        boto3.client("s3").create_bucket(Bucket="polars-bucket")
+        df.write_parquet(path)
+        result = pl.read_parquet(path)
+
+    assert result.equals(df)
+```
+
+## s3fs
+
+s3fs uses aiobotocore clients underneath, so it is covered automatically in
+in-process mode &mdash; no server required:
+
+```python
+import s3fs
+from aiomoto import mock_aws
+
+
+def test_s3fs_sync_usage() -> None:
+    with mock_aws():
+        fs = s3fs.S3FileSystem(asynchronous=False, anon=False)
+        fs.call_s3("create_bucket", Bucket="bucket-123")
+        fs.call_s3("put_object", Bucket="bucket-123", Key="test.txt", Body=b"hi")
+        assert fs.cat("bucket-123/test.txt") == b"hi"
+```
+
+!!! warning "Close filesystems inside the context"
+
+    s3fs caches filesystem instances. Create them inside `mock_aws` and close them
+    so finalizers don't run against a closed or different event loop.

--- a/docs/guides/server-mode.md
+++ b/docs/guides/server-mode.md
@@ -1,0 +1,191 @@
+# Server mode
+
+aiomoto defaults to Moto's **in-process** mode, which patches botocore and
+aiobotocore so no server runs. Pass `server_mode=True` to start a local Moto server
+instead:
+
+```python
+import boto3
+from aiomoto import mock_aws
+
+
+def test_server_mode() -> None:
+    with mock_aws(server_mode=True) as ctx:
+        client = boto3.client("s3")
+        assert client.meta.endpoint_url == ctx.server_endpoint
+        client.create_bucket(Bucket="server-mode")
+```
+
+!!! note "Requirements and trade-offs"
+
+    Server mode needs `moto[server]` installed (`pip install "aiomoto[server]"`).
+    It is typically slower than in-process mode, but it enables compatibility with
+    pandas and polars S3 I/O and other tooling that expects a real endpoint. Moto's
+    proxy mode remains unsupported.
+
+## Endpoint injection
+
+In server mode, `auto_endpoint` controls whether aiomoto rewrites client endpoints
+to point at the local server. Pass an [`AutoEndpointMode`](../reference/api.md#autoendpointmode):
+
+| Mode         | Value         | Behaviour                                                       |
+| ------------ | ------------- | -------------------------------------------------------------- |
+| `FORCE`      | `"force"`     | Always inject the server endpoint (the default in server mode).|
+| `IF_MISSING` | `"if_missing"`| Inject only when the client has no explicit `endpoint_url`.    |
+| `DISABLED`   | `"disabled"`  | Never inject; clients must target the server themselves.       |
+
+```python
+import boto3
+from aiomoto import AutoEndpointMode, mock_aws
+
+
+def test_force() -> None:
+    with mock_aws(server_mode=True) as ctx:
+        client = boto3.client("s3")
+        assert client.meta.endpoint_url == ctx.server_endpoint
+        client.create_bucket(Bucket="server-mode")
+
+
+def test_if_missing() -> None:
+    with mock_aws(server_mode=True, auto_endpoint=AutoEndpointMode.IF_MISSING):
+        client = boto3.client("s3", endpoint_url="http://example.com")
+        assert client.meta.endpoint_url == "http://example.com"
+
+
+def test_disabled() -> None:
+    with mock_aws(server_mode=True, auto_endpoint=AutoEndpointMode.DISABLED) as ctx:
+        client = boto3.client("s3", endpoint_url=ctx.server_endpoint)
+        client.create_bucket(Bucket="server-mode-explicit")
+```
+
+`auto_endpoint` requires `server_mode=True`; supplying any mode other than
+`DISABLED` in in-process mode raises
+[`AutoEndpointError`](../reference/api.md#exceptions).
+
+## Attaching to an existing server
+
+Pass a `server_port` to attach to a server that is already running rather than
+starting a new one. This keeps the context in "client mode" (no server start/stop)
+while still injecting the endpoint:
+
+```python
+from aiomoto import mock_aws
+
+
+def test_attach() -> None:
+    with mock_aws(server_mode=True) as server:
+        port = server.server_port
+        assert port is not None
+        # In another process, pass server_port to reuse the existing server.
+        with mock_aws(server_mode=True, server_port=port) as client:
+            assert client.server_endpoint == server.server_endpoint
+```
+
+## Parallel test runs
+
+Server mode is safe under parallel test runners such as
+[pytest-xdist](https://pytest-xdist.readthedocs.io/). Each xdist worker is a separate
+process, so a `mock_aws(server_mode=True)` context in one worker starts its own Moto
+server on an OS-assigned ephemeral port with a fully isolated backend &mdash; there
+are no port clashes and no shared state between workers.
+
+### Recommended fixture layout
+
+A Moto server is comparatively slow to start, so the recommended pattern is to start
+**one server per worker** and keep it alive for the whole session, then create and
+tear down resources (S3 buckets, DynamoDB tables, and so on) per test:
+
+- A **session-scoped, `autouse`** fixture enters `mock_aws(server_mode=True)` once.
+  xdist runs each worker in its own process, so every worker gets its own server.
+- **Function-scoped** fixtures create the resources a test needs and remove them when
+  the test finishes, so Moto's persistent backends don't leak state between tests.
+
+```python title="conftest.py"
+from collections.abc import Iterator
+
+import boto3
+from mypy_boto3_s3.service_resource import Bucket
+import pytest
+
+from aiomoto import mock_aws
+
+
+@pytest.fixture(scope="session", autouse=True)
+def aiomoto_context() -> Iterator[None]:
+    """Start one Moto server per xdist worker, kept alive for the whole session."""
+    with mock_aws(server_mode=True):
+        yield
+
+
+@pytest.fixture
+def s3_bucket() -> Iterator[Bucket]:
+    """Create an S3 bucket for a single test, then tear it down afterwards."""
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    bucket = s3.Bucket("example-bucket")
+    bucket.create()
+    yield bucket
+    bucket.objects.all().delete()
+    bucket.delete()
+```
+
+```python title="test_s3.py"
+from mypy_boto3_s3.service_resource import Bucket
+
+
+def test_round_trip(s3_bucket: Bucket) -> None:
+    s3_bucket.put_object(Key="hello.txt", Body=b"hi")
+    assert s3_bucket.Object("hello.txt").get()["Body"].read() == b"hi"
+```
+
+The fixture yields a strongly typed boto3
+[`Bucket`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/service-resource/index.html)
+resource bound to the test's bucket, so tests work with the bucket object directly
+instead of passing its name around. The `Bucket` type comes from
+[boto3-stubs](https://pypi.org/project/boto3-stubs/) (`pip install "boto3-stubs[s3]"`),
+a type-checking-only dependency; import it under `typing.TYPE_CHECKING` if you would
+rather not import it at runtime.
+
+Run it with xdist as usual:
+
+```bash
+pytest -n logical
+```
+
+Each worker starts its server once, every test gets a clean `example-bucket`, and a
+bucket in one worker never collides with another worker's because each worker has its
+own isolated backend.
+
+## Server registry files
+
+When aiomoto starts a server it records a registry file under the directory named by
+the `AIOMOTO_SERVER_REGISTRY_DIR` environment variable and exposes the path via
+`ctx.server_registry_path`. Files use the pattern:
+
+```text
+${AIOMOTO_SERVER_REGISTRY_DIR}/aiomoto-server-<uuid>.json
+```
+
+and contain payloads like:
+
+```json
+{
+  "endpoint": "http://127.0.0.1:12345",
+  "host": "127.0.0.1",
+  "pid": 1234,
+  "port": 12345
+}
+```
+
+Registry entries older than 24 hours are treated as stale and cleaned up when a new
+server is started.
+
+## Context attributes
+
+In server mode the context exposes these read-only attributes:
+
+| Attribute               | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `server_endpoint`       | The base URL of the running server.                  |
+| `server_host`           | The host the server bound to.                        |
+| `server_port`           | The port the server bound to.                        |
+| `server_registry_path`  | Path to the registry file aiomoto wrote.             |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,106 @@
+---
+icon: lucide/cloud
+---
+
+# aiomoto
+
+## Moto-style AWS mocks for aiobotocore
+
+`aiomoto` is [Moto](https://docs.getmoto.org/) for
+[aiobotocore](https://github.com/aio-libs/aiobotocore), while staying compatible
+with classic botocore / boto3. It adapts Moto's stubber so async and sync clients
+share the same in-memory backend: you can write to a mock S3 bucket with boto3 and
+read it back via aiobotocore in the same process.
+
+<div class="grid cards" markdown>
+
+-   :material-flash:{ .lg .middle } **One backend, both worlds**
+
+    ---
+
+    A single Moto backend is shared between synchronous boto3/botocore clients and
+    asynchronous aiobotocore clients in the same process.
+
+    [:octicons-arrow-right-24: Quick start](getting-started/quickstart.md)
+
+-   :material-server-network:{ .lg .middle } **No server required**
+
+    ---
+
+    Defaults to Moto's in-process mode &mdash; no port clashes, no race conditions,
+    safe to run tests in parallel. Server mode is opt-in when you need it.
+
+    [:octicons-arrow-right-24: Server mode](guides/server-mode.md)
+
+-   :material-table:{ .lg .middle } **Pandas & Polars S3**
+
+    ---
+
+    Optional integrations route `s3://` reads and writes through Moto in server
+    mode for pandas and polars.
+
+    [:octicons-arrow-right-24: DataFrame I/O](guides/dataframes.md)
+
+-   :material-package-variant:{ .lg .middle } **Drop-in install**
+
+    ---
+
+    `pip install aiomoto`, then use `mock_aws` exactly like Moto &mdash; as a
+    context manager or a decorator.
+
+    [:octicons-arrow-right-24: Install](getting-started/installation.md)
+
+</div>
+
+## Quick start
+
+```python
+import boto3
+from aiobotocore.session import AioSession
+from aiomoto import mock_aws
+
+
+async def demo() -> None:
+    async with mock_aws():
+        # Write with a synchronous boto3 client.
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="example")
+
+        # Read it back with an async aiobotocore client.
+        session = AioSession()
+        async with session.create_client("s3", region_name="us-east-1") as s3:
+            result = await s3.list_buckets()
+            assert any(b["Name"] == "example" for b in result["Buckets"])
+```
+
+## Supported today
+
+- `mock_aws()` usable as `with` or `async with`, guarding against real HTTP requests.
+- Actively exercised in tests: S3 (CRUD + listings + streaming reads), DynamoDB
+  (create/describe/put/get), Secrets Manager, SES, SNS, SQS, KMS, STS, Lambda, Events,
+  Kafka/MSK, and s3fs async integration &mdash; all sharing one Moto backend between
+  sync boto3/botocore and async aiobotocore clients.
+- Other Moto services often work out of the box through the same patch layer; if you
+  hit a service-specific gap, open an issue with a minimal repro so we can add a
+  focused slice.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+-   [:octicons-download-24: __Install aiomoto__](getting-started/installation.md)
+
+    pip, plus the Moto service extras and the pandas / polars integrations.
+
+-   [:octicons-play-24: __Run your first mock__](getting-started/quickstart.md)
+
+    Mock S3 from sync and async clients in under a minute.
+
+-   [:octicons-book-24: __Guides__](guides/contexts-and-decorators.md)
+
+    Contexts and decorators, server mode, and DataFrame I/O.
+
+-   [:octicons-gear-24: __API reference__](reference/api.md)
+
+    `mock_aws`, `mock_aws_decorator`, `AutoEndpointMode`, and the exception types.
+
+</div>

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,106 @@
+# API reference
+
+Everything below is importable from the top-level `aiomoto` package.
+
+```python
+from aiomoto import (
+    AutoEndpointMode,
+    mock_aws,
+    mock_aws_decorator,
+    __version__,
+)
+```
+
+## `mock_aws`
+
+```python
+mock_aws(
+    func=None,
+    *,
+    reset=True,
+    remove_data=True,
+    config=None,
+    server_mode=False,
+    server_port=None,
+    auto_endpoint=None,
+)
+```
+
+A drop-in replacement for Moto's `mock_aws`. Use it as a context manager
+(`with` / `async with`) or as a decorator over a sync or async callable. When
+called with keyword arguments and no function, it returns a reusable
+context/decorator object.
+
+| Parameter       | Type                    | Default | Description                                                                             |
+| --------------- | ----------------------- | ------- | --------------------------------------------------------------------------------------- |
+| `func`          | callable \| `None`      | `None`  | The function being decorated when used as `@mock_aws` without parentheses.              |
+| `reset`         | `bool`                  | `True`  | Reset Moto's backends when the context starts.                                          |
+| `remove_data`   | `bool`                  | `True`  | Remove backend data when the context exits.                                             |
+| `config`        | `Config \| None`        | `None`  | Optional Moto config override (in-process mode only).                                   |
+| `server_mode`   | `bool`                  | `False` | Start a local Moto server instead of patching in process.                               |
+| `server_port`   | `int \| None`           | `None`  | Attach to a server already listening on this port (requires `server_mode=True`).        |
+| `auto_endpoint` | `AutoEndpointMode \| None` | `None` | Endpoint-injection strategy in server mode (defaults to `FORCE` when `server_mode`).    |
+
+### Context attributes
+
+When used as a context manager in server mode, the returned object exposes:
+
+| Attribute              | Type          | Description                                  |
+| ---------------------- | ------------- | -------------------------------------------- |
+| `server_endpoint`      | `str \| None` | Base URL of the running server.              |
+| `server_host`          | `str \| None` | Host the server bound to.                    |
+| `server_port`          | `int \| None` | Port the server bound to.                    |
+| `server_registry_path` | `str \| None` | Path to the registry file aiomoto wrote.     |
+
+## `mock_aws_decorator`
+
+```python
+mock_aws_decorator(
+    func=None,
+    *,
+    reset=True,
+    remove_data=True,
+    config=None,
+    server_mode=False,
+    server_port=None,
+    auto_endpoint=None,
+)
+```
+
+A decorator factory mirroring Moto's `mock_aws` wrapper, exported for teams that
+prefer an explicitly decorator-only name. Parentheses are optional:
+`@mock_aws_decorator` uses the defaults, while `@mock_aws_decorator(reset=False)`
+preconfigures behaviour. Accepts the same keyword arguments as `mock_aws`.
+
+## `AutoEndpointMode`
+
+A `StrEnum` selecting how endpoints are injected in [server mode](../guides/server-mode.md):
+
+| Member       | Value          | Behaviour                                                       |
+| ------------ | -------------- | -------------------------------------------------------------- |
+| `FORCE`      | `"force"`      | Always inject the server endpoint (default in server mode).    |
+| `IF_MISSING` | `"if_missing"` | Inject only when the client has no explicit `endpoint_url`.    |
+| `DISABLED`   | `"disabled"`   | Never inject; clients target the server themselves.            |
+
+## Exceptions
+
+All exception types subclass the built-in `Exception` and are importable from
+`aiomoto`:
+
+| Exception                       | Raised when                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `RealHTTPRequestBlockedError`   | A real HTTP request is attempted while mocking.          |
+| `AutoEndpointError`             | Server-mode auto-endpoint configuration is invalid.      |
+| `InProcessModeError`            | In-process mode state is invalid or unavailable.         |
+| `ModeConflictError`             | In-process and server-mode settings conflict.            |
+| `ProxyModeError`                | Moto proxy mode is requested (unsupported).              |
+| `ServerModeConfigurationError`  | Server-mode configuration is invalid.                    |
+| `ServerModeDependencyError`     | Server-mode dependencies are missing.                    |
+| `ServerModeEndpointError`       | Server-mode endpoint discovery fails.                    |
+| `ServerModeHealthcheckError`    | A server-mode healthcheck fails.                         |
+| `ServerModePortError`           | An invalid or conflicting server port is supplied.       |
+| `ServerModeRequiredError`       | Server mode is required but not enabled.                 |
+
+## `__version__`
+
+The installed package version as a string.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ ft-test = [
     "pytest-xdist[psutil]>=3.8.0",
     "s3fs>=2024.6.0",
 ]
+docs = ["zensical==0.0.42"]
 
 [build-system]
 requires = ["uv_build>=0.11.16,<0.12.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,9 @@ xray = ["moto[xray]>=5.1.5,<=5.2.1"]
 pandas = [
     "moto[server]>=5.1.5,<=5.2.1",
     "pandas>=2.2.0,<=3.0.3",
+    "fsspec>=2024.6.0",
+    "s3fs>=2024.6.0",
+    "pyarrow>=22.0.0",
 ]
 polars = [
     "moto[server]>=5.1.5,<=5.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -401,8 +401,11 @@ organizations = [
     { name = "moto" },
 ]
 pandas = [
+    { name = "fsspec" },
     { name = "moto", extra = ["server"] },
     { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "s3fs" },
 ]
 panorama = [
     { name = "moto" },
@@ -569,6 +572,7 @@ ft-test = [
 [package.metadata]
 requires-dist = [
     { name = "aiobotocore", specifier = ">=2.24.1,<=3.7.0" },
+    { name = "fsspec", marker = "extra == 'pandas'", specifier = ">=2024.6.0" },
     { name = "moto", specifier = ">=5.1.5,<=5.2.1" },
     { name = "moto", extras = ["acm"], marker = "extra == 'acm'", specifier = ">=5.1.5,<=5.2.1" },
     { name = "moto", extras = ["acmpca"], marker = "extra == 'acmpca'", specifier = ">=5.1.5,<=5.2.1" },
@@ -694,6 +698,8 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.0,<=3.0.3" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.35.1,<=1.40.1" },
+    { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=22.0.0" },
+    { name = "s3fs", marker = "extra == 'pandas'", specifier = ">=2024.6.0" },
 ]
 provides-extras = ["acm", "acmpca", "all", "amp", "apigateway", "apigatewayv2", "applicationautoscaling", "appsync", "athena", "autoscaling", "awslambda", "awslambda-simple", "backup", "batch", "batch-simple", "budgets", "ce", "cloudformation", "cloudfront", "cloudtrail", "cloudwatch", "codebuild", "codecommit", "codepipeline", "cognitoidentity", "cognitoidp", "comprehend", "config", "databrew", "datapipeline", "datasync", "dax", "dms", "ds", "dynamodb", "dynamodbstreams", "ebs", "ec2", "ec2instanceconnect", "ecr", "ecs", "efs", "eks", "elasticache", "elasticbeanstalk", "elastictranscoder", "elb", "elbv2", "emr", "emrcontainers", "emrserverless", "es", "events", "firehose", "forecast", "glacier", "glue", "greengrass", "guardduty", "iam", "inspector2", "iot", "iotdata", "ivs", "kinesis", "kinesisvideo", "kinesisvideoarchivedmedia", "kms", "logs", "managedblockchain", "mediaconnect", "medialive", "mediapackage", "mediastore", "mediastoredata", "meteringmarketplace", "mq", "opsworks", "organizations", "panorama", "personalize", "pinpoint", "polly", "proxy", "quicksight", "ram", "rds", "redshift", "redshiftdata", "rekognition", "resourcegroups", "resourcegroupstaggingapi", "route53", "route53resolver", "s3", "s3control", "s3crc32c", "sagemaker", "scheduler", "sdb", "secretsmanager", "server", "servicediscovery", "servicequotas", "ses", "signer", "sns", "sqs", "ssm", "ssoadmin", "stepfunctions", "sts", "support", "swf", "textract", "timestreamwrite", "transcribe", "wafv2", "xray", "pandas", "polars"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -551,6 +551,9 @@ dev = [
     { name = "types-aiobotocore" },
     { name = "types-aiobotocore-full" },
 ]
+docs = [
+    { name = "zensical" },
+]
 ft-test = [
     { name = "coverage" },
     { name = "freezegun" },
@@ -716,6 +719,7 @@ dev = [
     { name = "types-aiobotocore", specifier = ">=2.24.1" },
     { name = "types-aiobotocore-full", specifier = ">=2.24.1" },
 ]
+docs = [{ name = "zensical", specifier = "==0.0.42" }]
 ft-test = [
     { name = "coverage", specifier = ">=7.6.9" },
     { name = "freezegun", specifier = ">=1.5.1" },
@@ -1314,6 +1318,15 @@ wheels = [
 ]
 
 [[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,6 +1683,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
     { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
     { url = "https://files.pythonhosted.org/packages/41/a0/b91504515c1f9a299fc157967ffbd2f0321bce0516a3d5b89f6f4cad0355/lazy_object_proxy-1.12.0-pp39.pp310.pp311.graalpy311-none-any.whl", hash = "sha256:c3b2e0af1f7f77c4263759c4824316ce458fabe0fceadcd24ef8ca08b2d1e402", size = 15072, upload-time = "2025-08-22T13:50:05.498Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -2634,6 +2656,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3483,4 +3518,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/dd/04e89ab92aed1ef9e36c76ef095fb587ffcbe4162aa7f3fe6d63aafade4a/zensical-0.0.42.tar.gz", hash = "sha256:cc346b833868a59412fe8d8498a152be90be9f3d8fb87e1f1a1c2e1146cbae1b", size = 3931093, upload-time = "2026-05-15T10:22:45.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/19/2ca4e52769307959f7485d4c5da7b24787339787c1cbc371885cef448e50/zensical-0.0.42-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bffd7a34b570fa3ccadf1d23babb0f7c4851c6b626e4fc8ed9f21c2eaae85968", size = 12705326, upload-time = "2026-05-15T10:22:07.905Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/82/0832b0d2c0c2800174141d5519a017105d3dace9194e2c29730e7a676adf/zensical-0.0.42-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee1a79789f9462ef44a4b6ebbfc8b5bf4b2447607da8bc5b35bc9c4ce4ea2370", size = 12568663, upload-time = "2026-05-15T10:22:11.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/87/272b3998322958ca38f09323d2347cb121dfc851477c36962b71319242a5/zensical-0.0.42-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e9a5d508ce8d1b07d8417f0623be476f6b37d445ab4356481a71e613a7979d6", size = 12948460, upload-time = "2026-05-15T10:22:13.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1b/e5f153401f162f48cae2d58e96b95fd39ba5bd1728fb5881a60e502f4e1d/zensical-0.0.42-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fbc0951a676e48afe7df3a9b2a30958dcf9c426ed2480972d3c04d6de485ba3", size = 12913460, upload-time = "2026-05-15T10:22:16.791Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4f/5186b4204bdfdf132851b7515a37b9602bfc153fb601db5fb244339bae52/zensical-0.0.42-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f0e96e53f39b9e4b929a25d9df70bd7fa8217166a854e2c8f3185983dd01500", size = 13276704, upload-time = "2026-05-15T10:22:19.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/df/b57b5fcc631ac7a4b4c6834d8cf0b88d3fca37c9db42fc6bbf9f097200ed/zensical-0.0.42-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7d586e57436d603e88acd856864f99f0771aef24bf6560b2de238417bd3817c", size = 12987069, upload-time = "2026-05-15T10:22:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3a/b326a44a065d98e89b472645ad33037201e3385340c2e6e35627b18ab3fa/zensical-0.0.42-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3c026f023330d67f986a94b68ffd36dc5066882e697e1125c37308d8d684135c", size = 13124195, upload-time = "2026-05-15T10:22:25.543Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/823740a662e357a8826dc8eeb87e06705e64219b2774430bc555f7c53d57/zensical-0.0.42-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e5908bc09cf5c1c50c9504241e37f89955daf3e89ba1b9d71c17972578b24804", size = 13182981, upload-time = "2026-05-15T10:22:28.89Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6d/9fe261267ac36a7d57051d790022408e9043bc925c9ad21971a1e5b6c3e8/zensical-0.0.42-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c0bf96b55f0a44e8716bcb334a16380ed56772b555145da775a7d8ac8678cb6f", size = 13332666, upload-time = "2026-05-15T10:22:32.249Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/57/9b0e4f131a7ad15cf1aca081748ea7336c084fb8e16be202a6bed32f595c/zensical-0.0.42-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:47cd99583738a8ab03fac4080741275c56e741a06dc8edfb541f4c1649a5ae69", size = 13270817, upload-time = "2026-05-15T10:22:35.388Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fd/bdb85cc444e4146e8970a22e48a903bfed5bf83276ad7d755caa415dda64/zensical-0.0.42-cp310-abi3-win32.whl", hash = "sha256:83090e53fba061967ecb3dff81500b1900f288bae108bf54084a2aeb6648ebd0", size = 12256227, upload-time = "2026-05-15T10:22:38.869Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b9/09d1f735c8e6d3eb61d176ed5ebcf658b65b126d7d4bbc03a7d366a1e17d/zensical-0.0.42-cp310-abi3-win_amd64.whl", hash = "sha256:2e4304e103f9cd5c637045bbae1ff29de3009ab01b16e99c2fd6d4bbceb7a3ee", size = 12486598, upload-time = "2026-05-15T10:22:42.158Z" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,112 @@
+[project]
+site_name = "aiomoto"
+site_description = "Moto-style AWS service mocks for aiobotocore"
+site_author = "Owen Lamont"
+site_url = "https://aiomoto-docs.pages.dev/"
+copyright = """
+Copyright &copy; 2025-2026 Owen Lamont
+"""
+
+repo_url = "https://github.com/owenlamont/aiomoto"
+edit_uri = "blob/main/docs/"
+repo_name = "owenlamont/aiomoto"
+
+nav = [
+  { "Home" = "index.md" },
+  { "Getting Started" = [
+    { "Installation" = "getting-started/installation.md" },
+    { "Quick Start" = "getting-started/quickstart.md" },
+  ]},
+  { "Guides" = [
+    { "Contexts and decorators" = "guides/contexts-and-decorators.md" },
+    { "Server mode" = "guides/server-mode.md" },
+    { "Pandas and Polars" = "guides/dataframes.md" },
+  ]},
+  { "Examples" = "examples.md" },
+  { "API reference" = "reference/api.md" },
+  { "About" = [
+    { "Motivation" = "about/motivation.md" },
+    { "Limitations" = "about/limitations.md" },
+  ]},
+]
+
+[project.theme]
+language = "en"
+
+features = [
+  "announce.dismiss",
+  "content.action.edit",
+  "content.action.view",
+  "content.code.annotate",
+  "content.code.copy",
+  "content.code.select",
+  "content.footnote.tooltips",
+  "content.tabs.link",
+  "content.tooltips",
+  "navigation.footer",
+  "navigation.indexes",
+  "navigation.instant",
+  "navigation.instant.prefetch",
+  "navigation.path",
+  "navigation.sections",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+primary = "teal"
+accent = "orange"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+primary = "teal"
+accent = "orange"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+[project.theme.icon]
+logo = "lucide/cloud"
+repo = "fontawesome/brands/github"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/owenlamont/aiomoto"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/python"
+link = "https://pypi.org/project/aiomoto/"
+
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## Summary

Adds a [Zensical](https://zensical.org/) documentation site, set up the same way as the [ryl](https://github.com/owenlamont/ryl) repo, and slims the README down to a concise overview that links into it.

Closes #108.

### Documentation (`docs/`)
- **Home** — overview, quick start, supported services.
- **Getting Started** — installation (service extras, server, pandas/polars) and quick start.
- **Guides** — contexts & decorators, server mode, pandas/polars DataFrame I/O.
- **Examples** — S3, DynamoDB, SQS, SNS, Secrets Manager, s3fs, streaming reads.
- **API reference** — `mock_aws`, `mock_aws_decorator`, `AutoEndpointMode`, and the exception types.
- **About** — motivation and limitations.

### Tooling
- `zensical.toml` site config; `docs = ["zensical==0.0.42"]` dependency group (locked in `uv.lock`).
- `/site/` gitignored; `docs/**` excluded from `rumdl` (Material/Zensical Markdown extensions it can't parse).
- `AGENTS.md` gains a "Documentation Site" section.

### README + wiki
- README trimmed to an overview that links to the docs.
- Retired the wiki: removed the wiki links from the README, `AGENTS.md`, and the motivation page (docs are now canonical).

### Parallel server-mode guidance
- Documented the recommended xdist fixture layout: a session-scoped autouse fixture holding one `mock_aws(server_mode=True)` per worker, plus per-test resource fixtures (the `s3_bucket` fixture yields a strongly-typed boto3 `Bucket`).
- Verified empirically: concurrent server-mode contexts get distinct ephemeral ports with isolated backends, and the documented fixture example passes under `pytest -n 4` (and type-checks with `ty`).

## Notes
- The docs still need a Cloudflare Pages project (build command `uv run --group docs zensical build --clean`, output dir `site`) pointing at this repo; `site_url` assumes `https://aiomoto-docs.pages.dev/`.