### PR TITLE
docs: refine home cards and nesting guide; bump to 0.5.2

### DIFF
--- a/docs/guides/contexts-and-decorators.md
+++ b/docs/guides/contexts-and-decorators.md
@@ -82,10 +82,42 @@ Leaving both at their defaults gives each test an isolated, empty AWS environmen
 
 ## Nesting
 
-Contexts are re-entrant: entering an already-active context simply increases an
-internal depth counter, and the backend is only torn down when the outermost
-context exits. This makes it safe to combine a decorator with an inner `with
-mock_aws():` block without losing state.
+Nesting `mock_aws` is safe, and nested contexts **share a single Moto backend**
+rather than getting isolated state. While an outer context is active, entering an
+inner one &mdash; whether the same context object re-entered or a separate
+`mock_aws()` block &mdash; does not reset the backend, and exiting it does not remove
+data. The backend is reset only on the outermost enter and torn down only on the
+outermost exit.
+
+In practice this means you can combine a decorator with an inner `with mock_aws():`
+block without losing state: the inner block sees everything the outer set up, and
+anything it creates stays visible after it exits.
+
+```python
+import boto3
+from aiomoto import mock_aws
+
+
+@mock_aws
+def test_nested() -> None:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="outer")
+
+    with mock_aws():
+        # The inner context shares the outer's backend (no reset).
+        assert any(b["Name"] == "outer" for b in s3.list_buckets()["Buckets"])
+        s3.create_bucket(Bucket="inner")
+
+    # The inner bucket is still here after the inner block exits.
+    names = {b["Name"] for b in s3.list_buckets()["Buckets"]}
+    assert names == {"outer", "inner"}
+```
+
+!!! note "Inner `reset` / `remove_data` are ignored while nested"
+
+    Because the Moto backend is shared and ref-counted, an inner context's `reset`
+    and `remove_data` flags have no effect while an outer context is active &mdash;
+    only the outermost context's settings apply.
 
 ## The `AWS_ENDPOINT_URL` gotcha
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,9 @@ read it back via aiobotocore in the same process.
 
     ---
 
-    Defaults to Moto's in-process mode &mdash; no port clashes, no race conditions,
-    safe to run tests in parallel. Server mode is opt-in when you need it.
+    Defaults to Moto's in-process mode &mdash; fast, with no server to spin up or
+    ports to manage. One flag opts into server mode for a real HTTP endpoint,
+    such as pandas / polars S3 I/O.
 
     [:octicons-arrow-right-24: Server mode](guides/server-mode.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiomoto"
-version = "0.5.1"
+version = "0.5.2"
 description = "Moto-style AWS service mocks for aiobotocore"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "aiomoto"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
## Summary

Small docs refinements plus a patch version bump to **0.5.2** so a release publishes the updated README/docs links and the pandas-extra fix to PyPI.

### Docs
- **Home "No server required" card** — reworded to lead with the genuine differentiator (speed / no server or ports to manage) and drop the misleading implication that parallel-safety is in-process-only (server mode is parallel-safe too). Notes that **one flag** opts into server mode for a real HTTP endpoint, e.g. pandas / polars S3 I/O.
- **Nesting guide** — corrected the mechanism. Nested contexts **share a single Moto backend** (not isolated state); the backend is reset only on the outermost enter and torn down only on the outermost exit, and an inner context's `reset`/`remove_data` are ignored while nested. Added a worked example. (Verified empirically before rewording.)

### Release prep
- `uv version --bump patch`: **0.5.1 → 0.5.2** (`pyproject.toml` + `uv.lock`).
- Publishing 0.5.2 ships: the slim, docs-linked README (PyPI currently shows the old one referencing the retired wiki) and the `pandas` extra fix (`fsspec`/`s3fs`/`pyarrow`) so `pip install "aiomoto[pandas]"` enables pandas S3 I/O.

## Notes
- All 202 tests pass on the fresh 3.14.5 env; prek clean.
- Merging auto-deploys the docs to https://aiomoto-docs.pages.dev/.
- The actual PyPI publish happens when tag `0.5.2` is pushed (`release.yml`) — I'll hold that for explicit go-ahead after merge.