### PR TITLE
docs: switch docs domain to aiomoto.pages.dev, add uv install, bump to 0.5.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ focus is a clean, reusable library API rather than a CLI entry point.
   the src module they cover and use the `test_` prefix.
 - **/docs/** – Zensical documentation source (Markdown). Built output goes to
   `/site/` (gitignored). This is the canonical project documentation, published at
-  <https://aiomoto-docs.pages.dev/>.
+  <https://aiomoto.pages.dev/>.
 - **.complexipy.toml** – Complexipy configuration.
 - **.coveragerc** – Coverage path mappings.
 - **ty.toml** – ty type checker configuration.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ botocore / boto3). It adapts Moto's stubber so async and sync clients share the 
 in-memory backend: you can write to a mock S3 bucket with boto3 and read it back via
 aiobotocore in the same process.
 
-📖 **Full documentation: <https://aiomoto-docs.pages.dev/>**
+📖 **Full documentation: <https://aiomoto.pages.dev/>**
 
 ## Supported today
 
@@ -22,12 +22,14 @@ aiobotocore in the same process.
 
 ```bash
 pip install aiomoto
+# or, in a uv project:
+uv add aiomoto
 ```
 
 aiomoto re-exposes Moto's service extras (for example `aiomoto[s3]`,
 `aiomoto[dynamodb]`, or `aiomoto[all]`), plus aiomoto-specific extras
 (`aiomoto[server]`, `aiomoto[pandas]`, `aiomoto[polars]`). See the
-[installation guide](https://aiomoto-docs.pages.dev/getting-started/installation/)
+[installation guide](https://aiomoto.pages.dev/getting-started/installation/)
 for details.
 
 ## Usage
@@ -57,28 +59,28 @@ async def demo() -> None:
 
 The documentation covers more:
 
-- [Contexts and decorators](https://aiomoto-docs.pages.dev/guides/contexts-and-decorators/)
+- [Contexts and decorators](https://aiomoto.pages.dev/guides/contexts-and-decorators/)
   — `with` / `async with`, `@mock_aws`, `reset` / `remove_data`, and the
   `AWS_ENDPOINT_URL` gotcha.
-- [Server mode](https://aiomoto-docs.pages.dev/guides/server-mode/) — run a local
+- [Server mode](https://aiomoto.pages.dev/guides/server-mode/) — run a local
   Moto server, endpoint-injection modes, and attaching to an existing server.
-- [Pandas and Polars](https://aiomoto-docs.pages.dev/guides/dataframes/) — `s3://`
+- [Pandas and Polars](https://aiomoto.pages.dev/guides/dataframes/) — `s3://`
   DataFrame I/O.
-- [Examples](https://aiomoto-docs.pages.dev/examples/) — S3, DynamoDB, SQS, SNS,
+- [Examples](https://aiomoto.pages.dev/examples/) — S3, DynamoDB, SQS, SNS,
   s3fs, and streaming reads.
-- [API reference](https://aiomoto-docs.pages.dev/reference/api/) — `mock_aws`,
+- [API reference](https://aiomoto.pages.dev/reference/api/) — `mock_aws`,
   `mock_aws_decorator`, `AutoEndpointMode`, and the exception types.
 
 ## Motivation
 
 Like many others I've wanted to use Moto with aiobotocore but found that wasn't
 supported. The
-[motivation page](https://aiomoto-docs.pages.dev/about/motivation/) explains the
+[motivation page](https://aiomoto.pages.dev/about/motivation/) explains the
 background and why aiomoto avoids depending on Moto's server mode by default.
 
 ## Limitations
 
 aiomoto keeps version ranges narrow and tested together, and a few integrations
 (notably pandas/polars S3 I/O) only work in server mode. See the
-[limitations page](https://aiomoto-docs.pages.dev/about/limitations/) for the full
+[limitations page](https://aiomoto.pages.dev/about/limitations/) for the full
 list, including free-threaded CPython support.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,39 +1,40 @@
 # Installation
 
-aiomoto is published on PyPI:
+aiomoto is published on PyPI and requires Python 3.11 or newer (it pulls in
+`aiobotocore`, `moto`, and `platformdirs`).
 
-```bash
-pip install aiomoto
-```
+=== "pip"
 
-It requires Python 3.11 or newer and pulls in `aiobotocore`, `moto`, and
-`platformdirs`.
+    ```bash
+    pip install aiomoto
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add aiomoto
+    ```
 
 ## Service extras
 
 aiomoto re-exposes Moto's service extras, so you can install Moto plus the
-dependencies required for the specific AWS services you use:
+dependencies required for the specific AWS services you use &mdash; for example S3:
 
-=== "S3"
+=== "pip"
 
     ```bash
     pip install "aiomoto[s3]"
     ```
 
-=== "DynamoDB"
+=== "uv"
 
     ```bash
-    pip install "aiomoto[dynamodb]"
+    uv add "aiomoto[s3]"
     ```
 
-=== "Everything"
-
-    ```bash
-    pip install "aiomoto[all]"
-    ```
-
-Moto's extras are service selectors for dependency sets (use `all` if you want
-everything) rather than features provided by aiomoto itself. See the
+Swap `s3` for any service you need (`dynamodb`, `sqs`, …), or use `all` for
+everything. Moto's extras are service selectors for dependency sets rather than
+features provided by aiomoto itself. See the
 [Moto install guide](https://docs.getmoto.org/en/latest/docs/getting_started.html)
 for the full list.
 
@@ -42,32 +43,52 @@ for the full list.
 [Server mode](../guides/server-mode.md) runs a local Moto server instead of
 patching in process. It needs Moto's `server` extra:
 
-```bash
-pip install "aiomoto[server]"
-```
+=== "pip"
+
+    ```bash
+    pip install "aiomoto[server]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "aiomoto[server]"
+    ```
 
 ## Pandas and Polars
 
 These integrations bundle everything needed for `s3://` DataFrame I/O, which always
-runs through [server mode](../guides/server-mode.md):
+runs through [server mode](../guides/server-mode.md).
 
-=== "Pandas"
+The `pandas` extra pulls in pandas, Moto's server extra, and the S3 stack (`fsspec`,
+`s3fs`, and `pyarrow` for parquet):
+
+=== "pip"
 
     ```bash
     pip install "aiomoto[pandas]"
     ```
 
-    Pulls in pandas, Moto's server extra, and the S3 stack (`fsspec`, `s3fs`, and
-    `pyarrow` for parquet).
+=== "uv"
 
-=== "Polars"
+    ```bash
+    uv add "aiomoto[pandas]"
+    ```
+
+The `polars` extra pulls in polars and Moto's server extra; polars reads `s3://`
+through its native object-store layer:
+
+=== "pip"
 
     ```bash
     pip install "aiomoto[polars]"
     ```
 
-    Pulls in polars and Moto's server extra; polars reads `s3://` through its
-    native object-store layer.
+=== "uv"
+
+    ```bash
+    uv add "aiomoto[polars]"
+    ```
 
 See [Pandas and Polars](../guides/dataframes.md) for how `s3://` paths are routed
 through Moto.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiomoto"
-version = "0.5.2"
+version = "0.5.3"
 description = "Moto-style AWS service mocks for aiobotocore"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "aiomoto"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_name = "aiomoto"
 site_description = "Moto-style AWS service mocks for aiobotocore"
 site_author = "Owen Lamont"
-site_url = "https://aiomoto-docs.pages.dev/"
+site_url = "https://aiomoto.pages.dev/"
 copyright = """
 Copyright &copy; 2025-2026 Owen Lamont
 """


### PR DESCRIPTION
## Summary

- **New docs domain** `https://aiomoto.pages.dev/` (drops the `-docs` suffix). A new Cloudflare Pages project named `aiomoto` replaces `aiomoto-docs` (Cloudflare can't rename the `*.pages.dev` subdomain in place, so a new project + repo re-attach was required). Updates all links in `README.md`, `AGENTS.md`, and `site_url` in `zensical.toml`.
- **uv install instructions** added alongside pip — tabbed `pip` / `uv` blocks across the installation guide (matching pyglobegl), plus a `uv add aiomoto` line in the README.
- **Version bump 0.5.2 → 0.5.3** (`uv version --bump patch`) so a PyPI release publishes the new docs-domain links.

## Notes
- 202 tests pass on the 3.14.5 env; prek clean; docs build clean; no `aiomoto-docs` references remain.
- The new `aiomoto` Pages project is connected to this repo (production branch `main`); merging redeploys it with the updated `site_url`.
- PyPI publish happens when tag `0.5.3` is pushed — held for your go-ahead after merge.