### PR TITLE
chore: release 0.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiomoto"
-version = "0.5.3"
+version = "0.5.4"
 description = "Moto-style AWS service mocks for aiobotocore"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "aiomoto"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
Version bump only — 0.5.3 → 0.5.4.

### Why now

#123 raised the dependency **upper** bounds on main but they are unpublished, so released aiomoto still caps `aiobotocore<=3.7.0`:

| Dependency | 0.5.3 (published) | 0.5.4 |
| --- | --- | --- |
| aiobotocore | `>=2.24.1,<=3.7.0` | `>=2.24.1,<=3.9.0` |
| pandas | `>=2.2.0,<=3.0.3` | `>=2.2.0,<=3.0.5` |
| polars | `>=1.35.1,<=1.42.1` | `>=1.35.1,<=1.43.2` |

Anyone on aiobotocore 3.8 or 3.9 currently cannot install aiomoto at all — the resolver either refuses or pins them back to 3.7. Releasing unblocks them.

The release also carries the StreamingBody adaptation those bounds depend on (aiobotocore 3.8 made `__aenter__` yield the body instead of the raw `ClientResponse`, and added sized reads).

### Verification

`prek run --all-files` clean, 202 tests pass locally.